### PR TITLE
fix: broadcast all SRT control packets to all connections

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -102,6 +102,10 @@ int is_srt_ack(void *pkt, int n) {
   return get_srt_type(pkt, n) == SRT_TYPE_ACK;
 }
 
+int is_srt_nak(void *pkt, int n) {
+  return get_srt_type(pkt, n) == SRT_TYPE_NAK;
+}
+
 int is_srtla_keepalive(void *pkt, int n) {
   return get_srt_type(pkt, n) == SRTLA_TYPE_KEEPALIVE;
 }

--- a/src/common.h
+++ b/src/common.h
@@ -100,6 +100,7 @@ int parse_port(char *port_str);
 int32_t get_srt_sn(void *pkt, int n);
 uint16_t get_srt_type(void *pkt, int n);
 int is_srt_ack(void *pkt, int n);
+int is_srt_nak(void *pkt, int n);
 int is_srt_shutdown(void *pkt, int n);
 
 int is_srtla_keepalive(void *pkt, int len);


### PR DESCRIPTION
## Summary

- Broadcasts all SRT control packets (ACKs, NAKs, ACKACK, KEEPALIVE, etc.) to all connections instead of only sending non-ACK packets to the last active connection
- Previously, NAKs were sent only to `last_address()` which could be a dead connection, causing retransmission failures

## Problem

When a connection dies or becomes unhealthy:
1. `last_address()` might still point to the dead connection
2. NAKs sent to that connection would be lost
3. The sender never receives the NAK and doesn't retransmit
4. Packet loss goes unrecovered

## Solution

Broadcast all SRT control packets to all connections in the group, matching the existing behavior for ACKs. This ensures NAKs reach the sender through at least one healthy connection.

## Safety

- SRT sender already handles duplicate NAKs safely (marks packet as handled after first NAK)
- SRT handles duplicate handshakes via state guards (`m_bConnecting` flag)
- ACKs already use this broadcast pattern successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Control packet broadcasting now includes negative acknowledgements (NAKs) alongside ACKs so all active group connections receive critical control packets.
  * Transmission error messages standardized to "Failed to send SRT packet" for clearer diagnostics.
  * Packet distribution logic refined for more consistent handling of control packets across connection groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->