### PR TITLE
perf: add batch packet processing with recvmmsg/sendmmsg

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -102,6 +102,10 @@ int is_srt_ack(void *pkt, int n) {
   return get_srt_type(pkt, n) == SRT_TYPE_ACK;
 }
 
+int is_srt_nak(void *pkt, int n) {
+  return get_srt_type(pkt, n) == SRT_TYPE_NAK;
+}
+
 int is_srtla_keepalive(void *pkt, int n) {
   return get_srt_type(pkt, n) == SRTLA_TYPE_KEEPALIVE;
 }

--- a/src/common.h
+++ b/src/common.h
@@ -100,6 +100,7 @@ int parse_port(char *port_str);
 int32_t get_srt_sn(void *pkt, int n);
 uint16_t get_srt_type(void *pkt, int n);
 int is_srt_ack(void *pkt, int n);
+int is_srt_nak(void *pkt, int n);
 int is_srt_shutdown(void *pkt, int n);
 
 int is_srtla_keepalive(void *pkt, int len);

--- a/src/receiver_main.cpp
+++ b/src/receiver_main.cpp
@@ -186,7 +186,7 @@ int main(int argc, char **argv) {
       // iterator/pointer invalidation.
       group_cnt = registry.groups().size();
       if (events[i].data.ptr == nullptr) {
-        srtla_handler.process_packet(ts);
+        srtla_handler.process_packets(ts);
       } else {
         auto raw_group = static_cast<srtla::connection::ConnectionGroup *>(
             events[i].data.ptr);


### PR DESCRIPTION
## Summary

- Use `recvmmsg` to receive up to 64 packets in a single syscall
- Use `sendmmsg` to broadcast to all connections in a single syscall

## Changes

**Receive batching (`srtla_handler.cpp`):**
- New `process_packets()` function using `recvmmsg` to receive up to 64 packets at once
- Each packet processed via `process_single_packet()` helper

**Send batching (`srt_handler.cpp`):**
- Broadcast to all connections using `sendmmsg` instead of individual `sendto` calls
- Sends to all connections in a single syscall

## Benefits

- Reduced syscall overhead under high packet rates
- Improved CPU efficiency for high-throughput scenarios
- Inspired by Moblin's batch receive pattern

## Dependencies

This PR is based on #9 (broadcast control packets to all connections)