### PR TITLE
Feature/anti dos and metricsImplement Stage 8 (FEC Deduplication) and Stage 9 (Keepalive Feedback) + Security Improvements

### DIFF
--- a/src/connection/connection_group.cpp
+++ b/src/connection/connection_group.cpp
@@ -25,6 +25,9 @@ ConnectionGroup::ConnectionGroup(const char *client_id, time_t timestamp)
     std::copy(random_bytes,
               random_bytes + (SRTLA_ID_LEN / 2),
               id_.begin() + (SRTLA_ID_LEN / 2));
+
+    // Initialize duplicate packet cache for FEC/selective duplication
+    dedup_cache_.fill(-1);
 }
 
 ConnectionGroup::~ConnectionGroup() {

--- a/src/connection/connection_group.h
+++ b/src/connection/connection_group.h
@@ -66,6 +66,17 @@ public:
     const std::string &stream_id() const { return stream_id_; }
     void set_stream_id(const std::string &sid) { stream_id_ = sid; }
 
+    // Selective duplication / FEC deduplication
+    bool is_duplicate_srt_packet(int32_t sn) {
+        if (sn < 0) return false;
+        std::size_t idx = static_cast<uint32_t>(sn) % DEDUP_CACHE_SIZE;
+        if (dedup_cache_[idx] == sn) {
+            return true;
+        }
+        dedup_cache_[idx] = sn;
+        return false;
+    }
+
 private:
     std::array<char, SRTLA_ID_LEN> id_ {};
     std::vector<ConnectionPtr> conns_;
@@ -85,6 +96,10 @@ private:
     // Anti-DoS state
     bool authenticated_ = false;
     std::string stream_id_;
+
+    // Selective duplication / FEC deduplication cache
+    static constexpr std::size_t DEDUP_CACHE_SIZE = 8192;
+    std::array<int32_t, DEDUP_CACHE_SIZE> dedup_cache_;
 };
 
 using ConnectionGroupPtr = std::shared_ptr<ConnectionGroup>;

--- a/src/connection/connection_group.h
+++ b/src/connection/connection_group.h
@@ -71,11 +71,13 @@ public:
         if (sn < 0) return false;
         std::size_t idx = static_cast<uint32_t>(sn) % DEDUP_CACHE_SIZE;
         if (dedup_cache_[idx] == sn) {
+            dedup_count_++;
             return true;
         }
         dedup_cache_[idx] = sn;
         return false;
     }
+    uint64_t dedup_count() const { return dedup_count_; }
 
 private:
     std::array<char, SRTLA_ID_LEN> id_ {};
@@ -98,8 +100,8 @@ private:
     std::string stream_id_;
 
     // Selective duplication / FEC deduplication cache
-    static constexpr std::size_t DEDUP_CACHE_SIZE = 8192;
     std::array<int32_t, DEDUP_CACHE_SIZE> dedup_cache_;
+    uint64_t dedup_count_ = 0;
 };
 
 using ConnectionGroupPtr = std::shared_ptr<ConnectionGroup>;

--- a/src/connection/connection_group.h
+++ b/src/connection/connection_group.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <string>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -59,6 +60,12 @@ public:
 
     void set_epoll_fd(int fd) { epoll_fd_ = fd; }
 
+    // Anti-DoS: StreamID authentication state
+    bool is_authenticated() const { return authenticated_; }
+    void set_authenticated(bool auth) { authenticated_ = auth; }
+    const std::string &stream_id() const { return stream_id_; }
+    void set_stream_id(const std::string &sid) { stream_id_ = sid; }
+
 private:
     std::array<char, SRTLA_ID_LEN> id_ {};
     std::vector<ConnectionPtr> conns_;
@@ -74,6 +81,10 @@ private:
 
     std::unordered_map<uint64_t, NakHashEntry> nak_seen_hash_;
     int epoll_fd_ = -1;
+
+    // Anti-DoS state
+    bool authenticated_ = false;
+    std::string stream_id_;
 };
 
 using ConnectionGroupPtr = std::shared_ptr<ConnectionGroup>;

--- a/src/connection/connection_registry.cpp
+++ b/src/connection/connection_registry.cpp
@@ -36,7 +36,11 @@ bool addresses_equal(const struct sockaddr_storage &a, const struct sockaddr_sto
 }
 
 bool conn_timed_out(const ConnectionPtr &conn, time_t ts) {
-    return (conn->last_received() + CONN_TIMEOUT) < ts;
+    // Adaptive timeout: connections that have successfully transmitted data
+    // get a longer grace period (30s) for IRL scenarios (tunnels, dead zones).
+    // New connections that never transmitted keep the default 15s timeout.
+    int timeout = (conn->stats().packets_received > 0) ? CONN_TIMEOUT_ACTIVE : CONN_TIMEOUT;
+    return (conn->last_received() + timeout) < ts;
 }
 
 } // namespace
@@ -147,10 +151,17 @@ void ConnectionRegistry::cleanup_inactive(time_t current_time,
             }
         }
 
-        if (connections.empty() && (group->created_at() + GROUP_TIMEOUT) < current_time) {
+        // Adaptive group timeout:
+        // - Unauthenticated groups (never validated StreamID): fast 5s timeout
+        // - Authenticated groups with no connections: standard 30s timeout
+        int timeout = group->is_authenticated() ? GROUP_TIMEOUT : PENDING_GROUP_TIMEOUT;
+        if (connections.empty() && (group->created_at() + timeout) < current_time) {
             group_it = groups_.erase(group_it);
             removed_groups++;
-            spdlog::info("[Group: {}] Group removed (no connections)", static_cast<void *>(group.get()));
+            spdlog::info("[Group: {}] Group removed ({}, timeout={}s)",
+                         static_cast<void *>(group.get()),
+                         group->is_authenticated() ? "no connections" : "unauthenticated",
+                         timeout);
         } else {
             if (before_conns != connections.size()) {
                 group->write_socket_info_file();

--- a/src/metrics/metrics_writer.h
+++ b/src/metrics/metrics_writer.h
@@ -81,6 +81,7 @@ public:
             out << "      \"created_at\": " << group->created_at() << ",\n";
             out << "      \"age_seconds\": " << (now - group->created_at()) << ",\n";
             out << "      \"srt_socket\": " << group->srt_socket() << ",\n";
+            out << "      \"dedup_packets_discarded\": " << group->dedup_count() << ",\n";
             out << "      \"connections\": [\n";
 
             bool first_conn = true;

--- a/src/metrics/metrics_writer.h
+++ b/src/metrics/metrics_writer.h
@@ -1,0 +1,153 @@
+#pragma once
+
+/*
+    srtla_rec - JSON Metrics Writer
+
+    Periodically writes per-group and per-connection metrics to a JSON file.
+    The Go Manager (StreamStudio) or any monitoring tool can read this file
+    to display real-time connection stats in the web UI.
+
+    Copyright (C) 2025 IRLServer.com
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+*/
+
+#include <cstdio>
+#include <ctime>
+#include <fstream>
+#include <string>
+
+#include <spdlog/spdlog.h>
+
+#include "../connection/connection_registry.h"
+#include "../security/rate_limiter.h"
+
+extern "C" {
+#include "../common.h"
+}
+
+namespace srtla::metrics {
+
+class MetricsWriter {
+public:
+    explicit MetricsWriter(const std::string &filepath)
+        : filepath_(filepath), tmp_filepath_(filepath + ".tmp") {}
+
+    /// Write current metrics to the JSON file.
+    /// Uses write-to-temp + rename for atomic updates (no partial reads).
+    void write(const connection::ConnectionRegistry &registry,
+               const security::RateLimiter &rate_limiter,
+               std::size_t pending_groups,
+               time_t now) {
+        // Throttle writes to every METRICS_WRITE_PERIOD seconds
+        if ((now - last_write_) < METRICS_WRITE_PERIOD) {
+            return;
+        }
+        last_write_ = now;
+
+        std::ofstream out(tmp_filepath_);
+        if (!out.is_open()) {
+            spdlog::warn("[metrics] Cannot open metrics file: {}", tmp_filepath_);
+            return;
+        }
+
+        out << "{\n";
+        out << "  \"timestamp\": " << now << ",\n";
+        out << "  \"total_groups\": " << registry.groups().size() << ",\n";
+        out << "  \"pending_groups\": " << pending_groups << ",\n";
+        out << "  \"rate_limiter_entries\": " << rate_limiter.size() << ",\n";
+        out << "  \"groups\": [\n";
+
+        bool first_group = true;
+        for (const auto &group : registry.groups()) {
+            if (!first_group) out << ",\n";
+            first_group = false;
+
+            // Group ID as hex string (first 16 bytes for readability)
+            char id_hex[33];
+            for (int i = 0; i < 16; i++) {
+                snprintf(id_hex + i * 2, 3, "%02x",
+                         static_cast<unsigned char>(group->id()[i]));
+            }
+            id_hex[32] = '\0';
+
+            out << "    {\n";
+            out << "      \"id\": \"" << id_hex << "\",\n";
+            out << "      \"authenticated\": " << (group->is_authenticated() ? "true" : "false") << ",\n";
+            out << "      \"stream_id\": \"" << escape_json(group->stream_id()) << "\",\n";
+            out << "      \"created_at\": " << group->created_at() << ",\n";
+            out << "      \"age_seconds\": " << (now - group->created_at()) << ",\n";
+            out << "      \"srt_socket\": " << group->srt_socket() << ",\n";
+            out << "      \"connections\": [\n";
+
+            bool first_conn = true;
+            for (const auto &conn : group->connections()) {
+                if (!first_conn) out << ",\n";
+                first_conn = false;
+
+                auto *addr_ptr = const_cast<struct sockaddr *>(
+                    reinterpret_cast<const struct sockaddr *>(&conn->address()));
+                const char *ip = print_addr(addr_ptr);
+                int port = port_no(addr_ptr);
+
+                const auto &stats = conn->stats();
+                time_t last_ago = now - conn->last_received();
+
+                out << "        {\n";
+                out << "          \"ip\": \"" << (ip ? ip : "unknown") << "\",\n";
+                out << "          \"port\": " << port << ",\n";
+                out << "          \"packets_received\": " << stats.packets_received << ",\n";
+                out << "          \"bytes_received\": " << stats.bytes_received << ",\n";
+                out << "          \"packets_lost\": " << stats.packets_lost << ",\n";
+                out << "          \"rtt_ms\": " << stats.rtt_ms << ",\n";
+                out << "          \"nack_count\": " << stats.nack_count << ",\n";
+                out << "          \"weight_percent\": " << static_cast<int>(stats.weight_percent) << ",\n";
+                out << "          \"error_points\": " << stats.error_points << ",\n";
+                out << "          \"sender_bitrate_bps\": " << stats.sender_bitrate_bps << ",\n";
+                out << "          \"window\": " << stats.window << ",\n";
+                out << "          \"in_flight\": " << stats.in_flight << ",\n";
+                out << "          \"last_received_ago_s\": " << last_ago << ",\n";
+                out << "          \"recovery_active\": " << (conn->recovery_start() > 0 ? "true" : "false") << "\n";
+                out << "        }";
+            }
+
+            out << "\n      ]\n";
+            out << "    }";
+        }
+
+        out << "\n  ]\n";
+        out << "}\n";
+        out.close();
+
+        // Atomic rename: guarantees readers never see partial JSON
+        std::rename(tmp_filepath_.c_str(), filepath_.c_str());
+    }
+
+private:
+    static std::string escape_json(const std::string &s) {
+        std::string result;
+        result.reserve(s.size());
+        for (char c : s) {
+            switch (c) {
+                case '"':  result += "\\\""; break;
+                case '\\': result += "\\\\"; break;
+                case '\n': result += "\\n"; break;
+                case '\r': result += "\\r"; break;
+                case '\t': result += "\\t"; break;
+                default:   result += c; break;
+            }
+        }
+        return result;
+    }
+
+    std::string filepath_;
+    std::string tmp_filepath_;
+    time_t last_write_ = 0;
+
+    static constexpr int METRICS_WRITE_PERIOD = 2; // Write every 2 seconds
+};
+
+} // namespace srtla::metrics

--- a/src/protocol/srtla_handler.cpp
+++ b/src/protocol/srtla_handler.cpp
@@ -4,6 +4,7 @@
 #include "srtla_handler.h"
 #include "pad_sendto.h"
 
+#include <algorithm>
 #include <arpa/inet.h>
 #include <cmath>
 #include <cstring>
@@ -176,8 +177,16 @@ void SRTLAHandler::process_single_packet(const char *buf, int n,
     }
 
     int32_t sn = get_srt_sn(const_cast<char *>(buf), n);
+    bool is_dup = false;
     if (sn >= 0) {
+        is_dup = group->is_duplicate_srt_packet(sn);
         register_packet(group, conn, sn);
+    }
+
+    if (is_dup) {
+        spdlog::trace("[Group: {}] Duplicate SRT packet (SN: {}) discarded",
+                      static_cast<void *>(group.get()), sn);
+        return;
     }
 
     if (!srt_handler_.forward_to_srt_server(group, buf, n)) {
@@ -481,14 +490,41 @@ void SRTLAHandler::handle_keepalive(ConnectionGroupPtr group,
         );
     }
     
-    // Echo the keepalive back to the sender
-    int ret = pad_sendto(srtla_socket_, buffer, length, 0,
-                     reinterpret_cast<const struct sockaddr *>(addr), kAddrLen);
-    if (ret != length) {
-        spdlog::error("[{}:{}] [Group: {}] Failed to send SRTLA Keepalive",
-                      print_addr(const_cast<struct sockaddr *>(reinterpret_cast<const struct sockaddr *>(addr))),
-                      port_no(const_cast<struct sockaddr *>(reinterpret_cast<const struct sockaddr *>(addr))),
-                      static_cast<void *>(group.get()));
+    // Echo the keepalive back to the sender (with feedback if it is an extended keepalive)
+    if (has_conn_info && length == SRTLA_KEEPALIVE_EXT_LEN) {
+        char resp_buf[SRTLA_KEEPALIVE_EXT_LEN + 4];
+        std::memcpy(resp_buf, buffer, SRTLA_KEEPALIVE_EXT_LEN);
+
+        // Feedback values
+        uint8_t weight = static_cast<uint8_t>(conn->stats().weight_percent);
+        uint8_t errors = static_cast<uint8_t>(std::min(static_cast<uint32_t>(conn->stats().error_points), 255U));
+        
+        // Link status: 1 if active (has transmitted/received data recently), 0 otherwise
+        uint16_t status = ((conn->last_received() + CONN_TIMEOUT) >= current_time) ? 1 : 0;
+        uint16_t status_be = htobe16(status);
+
+        resp_buf[38] = weight;
+        resp_buf[39] = errors;
+        std::memcpy(resp_buf + 40, &status_be, sizeof(status_be));
+
+        int ret = pad_sendto(srtla_socket_, resp_buf, sizeof(resp_buf), 0,
+                         reinterpret_cast<const struct sockaddr *>(addr), kAddrLen);
+        if (ret != sizeof(resp_buf)) {
+            spdlog::error("[{}:{}] [Group: {}] Failed to send SRTLA Keepalive with feedback",
+                          print_addr(const_cast<struct sockaddr *>(reinterpret_cast<const struct sockaddr *>(addr))),
+                          port_no(const_cast<struct sockaddr *>(reinterpret_cast<const struct sockaddr *>(addr))),
+                          static_cast<void *>(group.get()));
+        }
+    } else {
+        // Echo standard keepalive
+        int ret = pad_sendto(srtla_socket_, buffer, length, 0,
+                         reinterpret_cast<const struct sockaddr *>(addr), kAddrLen);
+        if (ret != length) {
+            spdlog::error("[{}:{}] [Group: {}] Failed to send SRTLA Keepalive",
+                          print_addr(const_cast<struct sockaddr *>(reinterpret_cast<const struct sockaddr *>(addr))),
+                          port_no(const_cast<struct sockaddr *>(reinterpret_cast<const struct sockaddr *>(addr))),
+                          static_cast<void *>(group.get()));
+        }
     }
 }
 

--- a/src/protocol/srtla_handler.cpp
+++ b/src/protocol/srtla_handler.cpp
@@ -140,6 +140,17 @@ void SRTLAHandler::process_single_packet(const char *buf, int n,
     group->set_last_address(*srtla_addr);
     metrics_.on_packet_received(conn, static_cast<size_t>(n));
 
+    // Anti-DoS Layer 3: StreamID validation for unauthenticated groups.
+    // Only runs once per group — when the SRT Conclusion handshake arrives.
+    // After authentication, this block is skipped entirely (zero overhead).
+    if (!group->is_authenticated()) {
+        try_authenticate_group(group, buf, n);
+        // If the group was just destroyed by failed authentication, bail out
+        if (!registry_.find_group_by_id(reinterpret_cast<const char *>(group->id().data()))) {
+            return;
+        }
+    }
+
     if (is_srt_nak_packet(buf, n)) {
         if (is_duplicate_nak(group, buf, n)) {
             spdlog::info("[{}:{}] [Group: {}] Duplicate NAK packet suppressed",
@@ -190,6 +201,23 @@ void SRTLAHandler::send_keepalive(const ConnectionPtr &conn, time_t ts) {
 }
 
 int SRTLAHandler::register_group(const struct sockaddr_storage *addr, const char *buffer, time_t ts) {
+    // Anti-DoS Layer 1: Rate limiting per source IP
+    const char *ip_str = print_addr(const_cast<struct sockaddr *>(
+        reinterpret_cast<const struct sockaddr *>(addr)));
+    if (!rate_limiter_.allow(std::string(ip_str), ts)) {
+        // Silently drop — don't even send REG_ERR to avoid amplification
+        return -1;
+    }
+
+    // Anti-DoS Layer 2: Cap on unauthenticated (pending) groups
+    if (count_pending_groups() >= MAX_PENDING_GROUPS) {
+        spdlog::warn("[{}:{}] Group registration rejected: pending group limit reached ({})",
+                     ip_str,
+                     port_no(const_cast<struct sockaddr *>(reinterpret_cast<const struct sockaddr *>(addr))),
+                     MAX_PENDING_GROUPS);
+        return -1;
+    }
+
     if (registry_.groups().size() >= MAX_GROUPS) {
         uint16_t header = htobe16(SRTLA_TYPE_REG_ERR);
         pad_sendto(srtla_socket_, &header, sizeof(header), 0,
@@ -462,6 +490,71 @@ void SRTLAHandler::handle_keepalive(ConnectionGroupPtr group,
                       port_no(const_cast<struct sockaddr *>(reinterpret_cast<const struct sockaddr *>(addr))),
                       static_cast<void *>(group.get()));
     }
+}
+
+void SRTLAHandler::try_authenticate_group(connection::ConnectionGroupPtr group,
+                                           const char *buf, int len) {
+    // Only attempt extraction if StreamID validation is configured
+    if (!stream_id_validator_ || !stream_id_validator_->is_enabled()) {
+        // No validator configured — auto-authenticate all groups
+        group->set_authenticated(true);
+        return;
+    }
+
+    // Try to extract StreamID from this packet (only works on SRT Conclusion handshakes)
+    std::string stream_id = security::StreamIdValidator::extract_stream_id(buf, len);
+    if (stream_id.empty()) {
+        // Not a Conclusion handshake — continue waiting.
+        // The PENDING_GROUP_TIMEOUT will clean up if no valid handshake arrives.
+        return;
+    }
+
+    // We found a StreamID — validate it
+    if (stream_id_validator_->validate(stream_id)) {
+        group->set_authenticated(true);
+        group->set_stream_id(stream_id);
+        spdlog::info("[Group: {}] StreamID '{}' authenticated successfully",
+                     static_cast<void *>(group.get()), stream_id);
+    } else {
+        spdlog::warn("[Group: {}] Rejected invalid StreamID: '{}'",
+                     static_cast<void *>(group.get()), stream_id);
+        // Destroy the group immediately — invalid StreamID
+        registry_.remove_group(group);
+    }
+}
+
+std::size_t SRTLAHandler::count_pending_groups() const {
+    std::size_t count = 0;
+    for (const auto &group : registry_.groups()) {
+        if (!group->is_authenticated()) {
+            count++;
+        }
+    }
+    return count;
+}
+
+
+void SRTLAHandler::notify_shutdown() {
+    constexpr socklen_t addr_len = sizeof(struct sockaddr_storage);
+    uint16_t header = htobe16(SRTLA_TYPE_REG_ERR);
+    int notified = 0;
+
+    for (const auto &group : registry_.groups()) {
+        for (const auto &conn : group->connections()) {
+            int ret = pad_sendto(srtla_socket_, &header, sizeof(header), 0,
+                             reinterpret_cast<const struct sockaddr *>(&conn->address()), addr_len);
+            if (ret == sizeof(header)) {
+                notified++;
+            }
+        }
+
+        // Also notify the last known address (might be different from any connection)
+        pad_sendto(srtla_socket_, &header, sizeof(header), 0,
+               reinterpret_cast<const struct sockaddr *>(&group->last_address()), addr_len);
+    }
+
+    spdlog::info("[shutdown] Sent disconnect notification to {} connection(s) across {} group(s)",
+                 notified, registry_.groups().size());
 }
 
 } // namespace srtla::protocol

--- a/src/protocol/srtla_handler.cpp
+++ b/src/protocol/srtla_handler.cpp
@@ -514,6 +514,12 @@ void SRTLAHandler::handle_keepalive(ConnectionGroupPtr group,
                           print_addr(const_cast<struct sockaddr *>(reinterpret_cast<const struct sockaddr *>(addr))),
                           port_no(const_cast<struct sockaddr *>(reinterpret_cast<const struct sockaddr *>(addr))),
                           static_cast<void *>(group.get()));
+        } else {
+            spdlog::debug("[{}:{}] [Group: {}] Keepalive feedback: weight={}% errors={} status={}",
+                          print_addr(const_cast<struct sockaddr *>(reinterpret_cast<const struct sockaddr *>(addr))),
+                          port_no(const_cast<struct sockaddr *>(reinterpret_cast<const struct sockaddr *>(addr))),
+                          static_cast<void *>(group.get()),
+                          static_cast<int>(weight), static_cast<int>(errors), status);
         }
     } else {
         // Echo standard keepalive

--- a/src/protocol/srtla_handler.h
+++ b/src/protocol/srtla_handler.h
@@ -34,6 +34,9 @@ public:
     // Graceful shutdown: notify all connected senders before exit
     void notify_shutdown();
 
+    // Anti-DoS: Count unauthenticated groups in registry
+    std::size_t count_pending_groups() const;
+
 private:
     // Process a single packet from the batch
     void process_single_packet(const char *buf, int len,
@@ -60,9 +63,6 @@ private:
     // Anti-DoS: Attempt StreamID validation on an unauthenticated group
     void try_authenticate_group(connection::ConnectionGroupPtr group,
                                 const char *buf, int len);
-
-    // Anti-DoS: Count unauthenticated groups in registry
-    std::size_t count_pending_groups() const;
 
     int srtla_socket_;
     connection::ConnectionRegistry &registry_;

--- a/src/protocol/srtla_handler.h
+++ b/src/protocol/srtla_handler.h
@@ -4,6 +4,8 @@
 #include "../connection/connection_registry.h"
 #include "../quality/metrics_collector.h"
 #include "../utils/nak_dedup.h"
+#include "../security/rate_limiter.h"
+#include "../security/stream_id_validator.h"
 
 namespace srtla::protocol {
 
@@ -20,6 +22,17 @@ public:
     // Process multiple packets in a batch using recvmmsg
     int process_packets(time_t ts);
     void send_keepalive(const connection::ConnectionPtr &conn, time_t ts);
+
+    // Anti-DoS: Set the StreamID validator (optional — nullptr disables validation)
+    void set_stream_id_validator(security::StreamIdValidator *validator) {
+        stream_id_validator_ = validator;
+    }
+
+    // Anti-DoS: Get the rate limiter for periodic cleanup
+    security::RateLimiter &rate_limiter() { return rate_limiter_; }
+
+    // Graceful shutdown: notify all connected senders before exit
+    void notify_shutdown();
 
 private:
     // Process a single packet from the batch
@@ -44,10 +57,22 @@ private:
                                      const connection_info_t &info,
                                      time_t current_time);
 
+    // Anti-DoS: Attempt StreamID validation on an unauthenticated group
+    void try_authenticate_group(connection::ConnectionGroupPtr group,
+                                const char *buf, int len);
+
+    // Anti-DoS: Count unauthenticated groups in registry
+    std::size_t count_pending_groups() const;
+
     int srtla_socket_;
     connection::ConnectionRegistry &registry_;
     SRTHandler &srt_handler_;
     quality::MetricsCollector &metrics_;
+
+    // Anti-DoS components
+    security::RateLimiter rate_limiter_;
+    security::StreamIdValidator *stream_id_validator_ = nullptr;
 };
 
 } // namespace srtla::protocol
+

--- a/src/receiver_config.h
+++ b/src/receiver_config.h
@@ -31,6 +31,9 @@ inline constexpr int REG1_RATE_WINDOW = 60;             // Rate limit window in 
 // Adaptive connection timeout
 inline constexpr int CONN_TIMEOUT_ACTIVE = 30;          // Extended timeout for connections that have transmitted data
 
+// Selective duplication / FEC deduplication
+inline constexpr std::size_t DEDUP_CACHE_SIZE = 8192;    // Direct-mapped cache slots per group (~32KB RAM per group)
+
 inline constexpr int KEEPALIVE_PERIOD = 1;
 inline constexpr int RECOVERY_CHANCE_PERIOD = 5;
 

--- a/src/receiver_config.h
+++ b/src/receiver_config.h
@@ -22,6 +22,15 @@ inline constexpr int CLEANUP_PERIOD = 3;
 inline constexpr int GROUP_TIMEOUT = 30;
 inline constexpr int CONN_TIMEOUT = 15;
 
+// Anti-DoS protection
+inline constexpr int PENDING_GROUP_TIMEOUT = 5;        // Fast timeout (5s) for unauthenticated groups
+inline constexpr std::size_t MAX_PENDING_GROUPS = 50;   // Cap on unauthenticated groups in memory
+inline constexpr int REG1_RATE_LIMIT = 5;               // Max REG1 packets per IP per window
+inline constexpr int REG1_RATE_WINDOW = 60;             // Rate limit window in seconds
+
+// Adaptive connection timeout
+inline constexpr int CONN_TIMEOUT_ACTIVE = 30;          // Extended timeout for connections that have transmitted data
+
 inline constexpr int KEEPALIVE_PERIOD = 1;
 inline constexpr int RECOVERY_CHANCE_PERIOD = 5;
 

--- a/src/receiver_main.cpp
+++ b/src/receiver_main.cpp
@@ -287,10 +287,7 @@ int main(int argc, char **argv) {
 
     // Metrics: Write JSON metrics file
     if (metrics_writer) {
-      std::size_t pending = 0;
-      for (const auto &g : registry.groups()) {
-        if (!g->is_authenticated()) pending++;
-      }
+      std::size_t pending = srtla_handler.count_pending_groups();
       metrics_writer->write(registry, srtla_handler.rate_limiter(), pending, ts);
     }
 

--- a/src/receiver_main.cpp
+++ b/src/receiver_main.cpp
@@ -1,5 +1,6 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <sys/epoll.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -18,6 +19,8 @@
 #include "quality/metrics_collector.h"
 #include "quality/quality_evaluator.h"
 #include "receiver_config.h"
+#include "metrics/metrics_writer.h"
+#include "security/stream_id_validator.h"
 #include "utils/network_utils.h"
 
 extern "C" {
@@ -27,6 +30,19 @@ extern "C" {
 namespace {
 
 constexpr int MAX_EPOLL_EVENTS = 10;
+
+// Global pointer for SIGHUP handler to reload StreamID config
+static srtla::security::StreamIdValidator *g_stream_id_validator = nullptr;
+static volatile sig_atomic_t g_reload_requested = 0;
+static volatile sig_atomic_t g_shutdown_requested = 0;
+
+void sighup_handler(int /*sig*/) {
+    g_reload_requested = 1;
+}
+
+void shutdown_handler(int /*sig*/) {
+    g_shutdown_requested = 1;
+}
 
 void set_socket_buffers(int socket_fd) {
   int bufsize = RECV_BUF_SIZE;
@@ -62,6 +78,15 @@ int main(int argc, char **argv) {
   args.add_argument("--log_level")
       .help("Set logging level (trace, debug, info, warn, error, critical)")
       .default_value(std::string{"info"});
+  args.add_argument("--streamid_file")
+      .help("Path to file with authorized StreamIDs (one per line). "
+            "If not set, StreamID validation is disabled. "
+            "Send SIGHUP to reload the file without restarting.")
+      .default_value(std::string{""});
+  args.add_argument("--metrics_file")
+      .help("Path to write JSON metrics file (updated every 2s). "
+            "If not set, metrics file is not written.")
+      .default_value(std::string{""});
 
   try {
     args.parse_args(argc, argv);
@@ -75,6 +100,8 @@ int main(int argc, char **argv) {
   const std::string srt_hostname = args.get<std::string>("--srt_hostname");
   const std::string srt_port = std::to_string(args.get<uint16_t>("--srt_port"));
   const std::string log_level = args.get<std::string>("--log_level");
+  const std::string streamid_file = args.get<std::string>("--streamid_file");
+  const std::string metrics_file = args.get<std::string>("--metrics_file");
 
   if (log_level == "trace") {
     spdlog::set_level(spdlog::level::trace);
@@ -160,13 +187,56 @@ int main(int argc, char **argv) {
 
   spdlog::info("srtla_rec is now running");
 
+  // Anti-DoS: Initialize StreamID validator if configured
+  srtla::security::StreamIdValidator stream_id_validator;
+  if (!streamid_file.empty()) {
+    if (stream_id_validator.load(streamid_file)) {
+      srtla_handler.set_stream_id_validator(&stream_id_validator);
+      g_stream_id_validator = &stream_id_validator;
+      spdlog::info("StreamID validation enabled. Send SIGHUP to reload.");
+    } else {
+      spdlog::warn("Failed to load StreamID file '{}' — validation disabled", streamid_file);
+    }
+  } else {
+    spdlog::info("StreamID validation disabled (no --streamid_file specified)");
+  }
+
+  // Install SIGHUP handler for hot-reload of StreamID file
+  struct sigaction sa {};
+  sa.sa_handler = sighup_handler;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = SA_RESTART;
+  sigaction(SIGHUP, &sa, nullptr);
+
+  // Install SIGTERM/SIGINT handlers for graceful shutdown
+  struct sigaction sa_shutdown {};
+  sa_shutdown.sa_handler = shutdown_handler;
+  sigemptyset(&sa_shutdown.sa_mask);
+  sa_shutdown.sa_flags = 0; // Do NOT use SA_RESTART — we want epoll_wait to be interrupted
+  sigaction(SIGTERM, &sa_shutdown, nullptr);
+  sigaction(SIGINT, &sa_shutdown, nullptr);
+
+  // Metrics: Initialize JSON writer if configured
+  std::unique_ptr<srtla::metrics::MetricsWriter> metrics_writer;
+  if (!metrics_file.empty()) {
+    metrics_writer = std::make_unique<srtla::metrics::MetricsWriter>(metrics_file);
+    spdlog::info("Metrics file enabled: {}", metrics_file);
+  }
+
   const auto keepalive_callback =
       [&srtla_handler](const srtla::connection::ConnectionPtr &conn,
                        time_t ts) { srtla_handler.send_keepalive(conn, ts); };
 
-  while (true) {
+  while (!g_shutdown_requested) {
     struct epoll_event events[MAX_EPOLL_EVENTS];
     int eventcnt = epoll_wait(epoll_fd, events, MAX_EPOLL_EVENTS, 1000);
+
+    // Check if epoll_wait was interrupted by a signal
+    if (eventcnt < 0) {
+      if (errno == EINTR) continue; // Signal interrupted — re-check g_shutdown_requested
+      spdlog::error("epoll_wait failed: {}", strerror(errno));
+      break;
+    }
 
     time_t ts = 0;
     if (get_seconds(&ts) != 0) {
@@ -202,11 +272,40 @@ int main(int argc, char **argv) {
     }
 
     registry.cleanup_inactive(ts, keepalive_callback);
+
+    // Anti-DoS: Periodic cleanup of rate limiter entries
+    srtla_handler.rate_limiter().cleanup(ts);
+
+    // Anti-DoS: Hot-reload StreamID file on SIGHUP
+    if (g_reload_requested) {
+      g_reload_requested = 0;
+      if (g_stream_id_validator) {
+        spdlog::info("SIGHUP received — reloading StreamID file");
+        g_stream_id_validator->reload();
+      }
+    }
+
+    // Metrics: Write JSON metrics file
+    if (metrics_writer) {
+      std::size_t pending = 0;
+      for (const auto &g : registry.groups()) {
+        if (!g->is_authenticated()) pending++;
+      }
+      metrics_writer->write(registry, srtla_handler.rate_limiter(), pending, ts);
+    }
+
     for (auto &group : registry.groups()) {
       quality_evaluator.evaluate_group(group, ts);
       load_balancer.adjust_weights(group, ts);
     }
   }
 
+  // ─── Graceful Shutdown ───
+  spdlog::info("Shutdown signal received — notifying connected senders...");
+  srtla_handler.notify_shutdown();
+  spdlog::info("srtla_rec shutdown complete.");
+
+  close(srtla_sock);
+  close(epoll_fd);
   return 0;
 }

--- a/src/security/rate_limiter.h
+++ b/src/security/rate_limiter.h
@@ -43,14 +43,12 @@ public:
             entry.window_start = now;
         }
 
-        entry.count++;
-
-        if (entry.count > REG1_RATE_LIMIT) {
-            spdlog::warn("[security] Rate limit exceeded for IP {}: {}/{} in {}s window",
-                         ip, entry.count, REG1_RATE_LIMIT, REG1_RATE_WINDOW);
+        if (entry.count >= REG1_RATE_LIMIT) {
+            spdlog::warn("[security] Rate limit exceeded for IP {}", ip);
             return false;
         }
 
+        entry.count++;
         return true;
     }
 

--- a/src/security/rate_limiter.h
+++ b/src/security/rate_limiter.h
@@ -1,0 +1,75 @@
+#pragma once
+
+/*
+    srtla_rec - Anti-DoS: IP-based Rate Limiter
+
+    Limits the number of REG1 (group registration) packets per source IP
+    within a configurable time window. Prevents attackers from flooding
+    the receiver with connection requests.
+
+    Copyright (C) 2025 IRLServer.com
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+*/
+
+#include <ctime>
+#include <string>
+#include <unordered_map>
+
+#include <spdlog/spdlog.h>
+
+#include "../receiver_config.h"
+
+namespace srtla::security {
+
+struct RateEntry {
+    int count = 0;
+    time_t window_start = 0;
+};
+
+class RateLimiter {
+public:
+    /// Returns true if the request from this IP should be allowed.
+    /// Returns false if the rate limit has been exceeded.
+    bool allow(const std::string &ip, time_t now) {
+        auto &entry = entries_[ip];
+
+        // Reset window if expired
+        if ((now - entry.window_start) >= REG1_RATE_WINDOW) {
+            entry.count = 0;
+            entry.window_start = now;
+        }
+
+        entry.count++;
+
+        if (entry.count > REG1_RATE_LIMIT) {
+            spdlog::warn("[security] Rate limit exceeded for IP {}: {}/{} in {}s window",
+                         ip, entry.count, REG1_RATE_LIMIT, REG1_RATE_WINDOW);
+            return false;
+        }
+
+        return true;
+    }
+
+    /// Remove entries that haven't been seen in 2x the rate window.
+    /// Call this periodically (e.g., from cleanup_inactive).
+    void cleanup(time_t now) {
+        for (auto it = entries_.begin(); it != entries_.end();) {
+            if ((now - it->second.window_start) >= REG1_RATE_WINDOW * 2) {
+                it = entries_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    std::size_t size() const { return entries_.size(); }
+
+private:
+    std::unordered_map<std::string, RateEntry> entries_;
+};
+
+} // namespace srtla::security

--- a/src/security/stream_id_validator.h
+++ b/src/security/stream_id_validator.h
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <fstream>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include <spdlog/spdlog.h>
@@ -58,7 +59,7 @@ public:
             return false;
         }
 
-        std::vector<std::string> new_ids;
+        std::unordered_set<std::string> new_ids;
         std::string line;
         while (std::getline(file, line)) {
             // Trim whitespace
@@ -70,7 +71,7 @@ public:
             std::string trimmed = line.substr(start, end - start + 1);
             // Skip empty lines and comments
             if (!trimmed.empty() && trimmed[0] != '#') {
-                new_ids.push_back(trimmed);
+                new_ids.insert(trimmed);
             }
         }
 
@@ -93,12 +94,7 @@ public:
         if (stream_id.empty()) {
             return false; // Empty StreamID is never valid when validation is on
         }
-        for (const auto &id : authorized_ids_) {
-            if (id == stream_id) {
-                return true;
-            }
-        }
-        return false;
+        return authorized_ids_.count(stream_id) > 0;
     }
 
     /// Extract the StreamID from an SRT packet buffer.
@@ -179,7 +175,7 @@ public:
     }
 
 private:
-    std::vector<std::string> authorized_ids_;
+    std::unordered_set<std::string> authorized_ids_;
     std::string filepath_;
     bool enabled_ = false;
 };

--- a/src/security/stream_id_validator.h
+++ b/src/security/stream_id_validator.h
@@ -1,0 +1,187 @@
+#pragma once
+
+/*
+    srtla_rec - Anti-DoS: StreamID Extraction & Validation
+
+    Extracts the SRT StreamID from SRT Conclusion handshake packets and
+    validates it against an authorized list loaded from a configuration file.
+    Supports hot-reload via SIGHUP.
+
+    The StreamID is carried in SRT handshake extension type 5 (SRT_CMD_SID),
+    which is only present in the Conclusion phase of the SRT handshake
+    (handshake_type = 0xFFFFFFFD).
+
+    Copyright (C) 2025 IRLServer.com
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+*/
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <spdlog/spdlog.h>
+
+namespace srtla::security {
+
+// SRT handshake constants
+inline constexpr uint32_t SRT_HS_TYPE_CONCLUSION = 0xFFFFFFFD;
+inline constexpr uint16_t SRT_CMD_SID = 5;
+inline constexpr int SRT_HANDSHAKE_MIN_SIZE = 64;
+
+class StreamIdValidator {
+public:
+    /// Load authorized StreamIDs from a file (one per line).
+    /// Lines starting with '#' are treated as comments.
+    /// Returns true if the file was loaded successfully.
+    bool load(const std::string &filepath) {
+        filepath_ = filepath;
+        return reload();
+    }
+
+    /// Reload the StreamID list from the previously configured file.
+    /// Can be called from a SIGHUP handler.
+    bool reload() {
+        if (filepath_.empty()) {
+            return false;
+        }
+
+        std::ifstream file(filepath_);
+        if (!file.is_open()) {
+            spdlog::warn("[security] Cannot open StreamID file: {}", filepath_);
+            return false;
+        }
+
+        std::vector<std::string> new_ids;
+        std::string line;
+        while (std::getline(file, line)) {
+            // Trim whitespace
+            auto start = line.find_first_not_of(" \t\r\n");
+            auto end = line.find_last_not_of(" \t\r\n");
+            if (start == std::string::npos) {
+                continue;
+            }
+            std::string trimmed = line.substr(start, end - start + 1);
+            // Skip empty lines and comments
+            if (!trimmed.empty() && trimmed[0] != '#') {
+                new_ids.push_back(trimmed);
+            }
+        }
+
+        authorized_ids_ = std::move(new_ids);
+        enabled_ = true;
+        spdlog::info("[security] Loaded {} authorized StreamID(s) from {}",
+                     authorized_ids_.size(), filepath_);
+        return true;
+    }
+
+    /// Returns true if StreamID validation is enabled.
+    bool is_enabled() const { return enabled_; }
+
+    /// Validate a StreamID against the authorized list.
+    /// Returns true if validation is disabled or the StreamID is authorized.
+    bool validate(const std::string &stream_id) const {
+        if (!enabled_) {
+            return true; // Validation disabled — allow all
+        }
+        if (stream_id.empty()) {
+            return false; // Empty StreamID is never valid when validation is on
+        }
+        for (const auto &id : authorized_ids_) {
+            if (id == stream_id) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// Extract the StreamID from an SRT packet buffer.
+    /// Returns the StreamID string, or empty string if:
+    /// - The packet is not an SRT control packet
+    /// - The packet is not a Conclusion handshake
+    /// - No StreamID extension (SRT_CMD_SID) is present
+    static std::string extract_stream_id(const char *buf, int len) {
+        if (len < SRT_HANDSHAKE_MIN_SIZE) {
+            return "";
+        }
+
+        const auto *p = reinterpret_cast<const uint8_t *>(buf);
+
+        // Check: SRT control packet (bit 0 of first byte set)
+        if ((p[0] & 0x80) == 0) {
+            return "";
+        }
+
+        // Check: Handshake type (control type = 0x0000, meaning first 2 bytes = 0x80 0x00)
+        if (p[0] != 0x80 || p[1] != 0x00) {
+            return "";
+        }
+
+        // Read handshake_type at offset 36 (big-endian uint32)
+        uint32_t hs_type = (uint32_t(p[36]) << 24) | (uint32_t(p[37]) << 16) |
+                           (uint32_t(p[38]) << 8) | uint32_t(p[39]);
+
+        // Only Conclusion handshakes carry the StreamID extension
+        if (hs_type != SRT_HS_TYPE_CONCLUSION) {
+            return "";
+        }
+
+        // Check ext_field at offset 22 — if 0, no extensions present
+        uint16_t ext_field = (uint16_t(p[22]) << 8) | uint16_t(p[23]);
+        if (ext_field == 0) {
+            return "";
+        }
+
+        // Walk the extension blocks starting at offset 64
+        int offset = SRT_HANDSHAKE_MIN_SIZE;
+        while (offset + 4 <= len) {
+            uint16_t ext_type = (uint16_t(p[offset]) << 8) | uint16_t(p[offset + 1]);
+            uint16_t ext_len = (uint16_t(p[offset + 2]) << 8) | uint16_t(p[offset + 3]);
+            int ext_bytes = ext_len * 4; // Length is in 32-bit words
+
+            if (ext_bytes <= 0 || offset + 4 + ext_bytes > len) {
+                break;
+            }
+
+            if (ext_type == SRT_CMD_SID) {
+                // The StreamID string is stored with per-word big-endian encoding.
+                // We need to swap each 4-byte group to recover the original string.
+                std::string result(ext_bytes, '\0');
+                for (int i = 0; i < ext_bytes; i += 4) {
+                    int remaining = std::min(4, ext_bytes - i);
+                    // Read the 4-byte word and reverse byte order
+                    for (int j = 0; j < remaining && j < 4; j++) {
+                        result[i + j] = static_cast<char>(p[offset + 4 + i + (3 - j)]);
+                    }
+                }
+
+                // Trim trailing null bytes
+                auto end = result.find_last_not_of('\0');
+                if (end != std::string::npos) {
+                    result.resize(end + 1);
+                } else {
+                    result.clear();
+                }
+
+                return result;
+            }
+
+            offset += 4 + ext_bytes;
+        }
+
+        return "";
+    }
+
+private:
+    std::vector<std::string> authorized_ids_;
+    std::string filepath_;
+    bool enabled_ = false;
+};
+
+} // namespace srtla::security


### PR DESCRIPTION
This PR implements Stage 8 (selective packet deduplication/FEC) and Stage 9 (bidirectional keepalive feedback) for `srtla_rec`, along with several security and stability improvements:

- **Stage 8 (FEC/Deduplication):** Implemented a direct-mapped sequence number cache (8192 slots) in `ConnectionGroup` to discard duplicate packets without forwarding them to the SRT server, while still acknowledging them to keep the connection alive.
- **Stage 9 (Keepalive Feedback):** Implemented 4-byte bidirectional keepalive feedback payload (weight, error points, link status) on keepalive responses.
- **Security & DoS Protection:** Added IP-based rate limiting (max 5 REG1/min/IP), pending connection caps (max 50), and aggressive timeouts (5s) for unauthenticated groups.
- **StreamID Validation:** Fast lookup via `std::unordered_set` with dynamic configuration hot-reload via `SIGHUP`.
- **Telemetry:** Atomic JSON metrics writer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Metrics export to JSON file with real-time connection and group statistics
  * Stream ID validation for connection authentication
  * IP-based rate limiting to prevent registration abuse
  * Signal-based graceful shutdown (SIGTERM/SIGINT) and Stream ID configuration hot-reload (SIGHUP)

* **Improvements**
  * Adaptive connection timeout based on packet activity
  * SRT packet deduplication to reduce redundant processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->